### PR TITLE
Use v2 in label to avoid confusion with v1

### DIFF
--- a/lib/Backend/Dropbox.php
+++ b/lib/Backend/Dropbox.php
@@ -39,7 +39,7 @@ class Dropbox extends Backend {
             ->setIdentifier('files_external_dropbox')
             ->addIdentifierAlias('\OC\Files\External_Storage\Dropbox') // legacy compat
             ->setStorageClass('\OCA\Files_external_dropbox\Storage\Dropbox')
-            ->setText($l->t('Dropbox'))
+            ->setText($l->t('Dropbox V2'))
             ->addParameters([
                 
             ])


### PR DESCRIPTION
When installed in 10.0.0 - 10.0.3 this appears exactly the same as the existing dropbox app which is not yet removed from the stable10 codebase: https://github.com/owncloud/core/pull/28073

This label means you can choose the new one easily in the JS list in the UI.