### PR TITLE
Compatibility with php5.6

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,6 +28,7 @@ Administrators and users (when enabled) can find external storage configuration 
     </types>
 
     <dependencies>
+        <php min-version="5.6.4"/>
         <owncloud min-version="10.0" max-version="10.0"/>
     </dependencies>
     <website>https://github.com/owncloud/files_external_dropbox/</website>

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
+    "config": {
+        "platform": {
+            "php": "5.6.4"
+        }
+    },
     "repositories": [
         {
             "type": "vcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9102b255c1e9a9dd8ccb4ebef876a4b5",
+    "content-hash": "bfe0d97d5b9905f37edffbeadac6f83e",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -500,24 +500,24 @@
         },
         {
             "name": "tightenco/collect",
-            "version": "v5.5.13",
+            "version": "v5.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/collect.git",
-                "reference": "dae85b18c6a2315645bca3dac37e3e408542efa8"
+                "reference": "73aa38b20d932f5e8f8ccf721e4c27f4304783d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/collect/zipball/dae85b18c6a2315645bca3dac37e3e408542efa8",
-                "reference": "dae85b18c6a2315645bca3dac37e3e408542efa8",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/73aa38b20d932f5e8f8ccf721e4c27f4304783d6",
+                "reference": "73aa38b20d932f5e8f8ccf721e4c27f4304783d6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=5.6.4"
             },
             "require-dev": {
-                "mockery/mockery": "~1.0",
-                "phpunit/phpunit": "~6.0"
+                "mockery/mockery": "^0.9.7",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "autoload": {
@@ -543,7 +543,7 @@
                 "collection",
                 "laravel"
             ],
-            "time": "2017-09-25T17:13:51+00:00"
+            "time": "2017-08-14T20:47:19+00:00"
         }
     ],
     "packages-dev": [],
@@ -556,5 +556,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.4"
+    }
 }


### PR DESCRIPTION
Platform was pinned to php version 5.6.4 and composer.lock was rebuild with that platform version.
Additionally updated `info.xml` to require at least php 5.6.4 

I manually tested with the following versions: 

```
PHP 5.6.31 (cli) (built: Aug  7 2017 20:28:40) 
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
```

```
PHP 7.0.23 (cli) (built: Sep 25 2017 08:07:03) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.0.23, Copyright (c) 1999-2017, by Zend Technologies
```

```
PHP 7.1.8 (cli) (built: Aug  7 2017 15:02:45) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.1.8, Copyright (c) 1999-2017, by Zend Technologies
```

closes #14 