### PR TITLE
Override third party libraries to check for filename casing

### DIFF
--- a/lib/Storage/CacheableFlysystemAdapter.php
+++ b/lib/Storage/CacheableFlysystemAdapter.php
@@ -54,8 +54,8 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 	 * @param \League\Flysystem\AdapterInterface $adapter
 	 */
 	protected function buildFlySystem(AdapterInterface $adapter) {
-	    $this->flysystem = new Filesystem($adapter, [Filesystem::IS_CASE_INSENSITIVE_STORAGE => $this->isCaseInsensitiveStorage]);
-	    $this->flysystem->addPlugin(new GetWithMetadata());
+		$this->flysystem = new Filesystem($adapter, [Filesystem::IS_CASE_INSENSITIVE_STORAGE => $this->isCaseInsensitiveStorage]);
+		$this->flysystem->addPlugin(new GetWithMetadata());
 	}
 
 	public function clearCache() {
@@ -93,7 +93,7 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 				$this->cacheContents[$location] = $this->flysystem->getMetadata($location);
 			} catch (FileNotFoundException $e) {
 				// do not store this info in cache as it might interfere with Upload process
-                return false;
+				return false;
 			}
 		}
 		return $this->cacheContents[$location];

--- a/lib/Storage/CacheableFlysystemAdapter.php
+++ b/lib/Storage/CacheableFlysystemAdapter.php
@@ -49,6 +49,7 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 
 	/**
 	 * Initialize the storage backend with a flyssytem adapter
+	 * Override parent method so the flysystem include information about storage case sensitivity
 	 *
 	 * @param \League\Flysystem\AdapterInterface $adapter
 	 */

--- a/lib/Storage/CacheableFlysystemAdapter.php
+++ b/lib/Storage/CacheableFlysystemAdapter.php
@@ -26,6 +26,8 @@ namespace OCA\Files_external_dropbox\Storage;
 use Icewind\Streams\IteratorDirectory;
 use League\Flysystem\FileNotFoundException;
 use OCP\Files\Storage\FlysystemStorageAdapter;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Plugin\GetWithMetadata;
 
 /**
  * Generic Cacheable adapter between flysystem adapters and owncloud's storage system
@@ -34,16 +36,26 @@ use OCP\Files\Storage\FlysystemStorageAdapter;
  */
 abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 	/**
-     * This property is used to check whether the storage is case insensitive or not
-     * @var boolean
-     */
-    protected $isCaseInsensitiveStorage = false;
+	 * This property is used to check whether the storage is case insensitive or not
+	 * @var boolean
+	 */
+	protected $isCaseInsensitiveStorage = false;
 
 	/**
 	 * Stores the results in cache for the current request to prevent multiple requests to the API
 	 * @var array
 	 */
 	protected $cacheContents = [];
+
+	/**
+	 * Initialize the storage backend with a flyssytem adapter
+	 *
+	 * @param \League\Flysystem\AdapterInterface $adapter
+	 */
+	protected function buildFlySystem(AdapterInterface $adapter) {
+	    $this->flysystem = new Filesystem($adapter, [Filesystem::IS_CASE_INSENSITIVE_STORAGE => $this->isCaseInsensitiveStorage]);
+	    $this->flysystem->addPlugin(new GetWithMetadata());
+	}
 
 	public function clearCache() {
 		$this->cacheContents = [];

--- a/lib/Storage/CacheableFlysystemAdapter.php
+++ b/lib/Storage/CacheableFlysystemAdapter.php
@@ -74,11 +74,6 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 		if ($location === '') {
 			$location = '/';
 		}
-		return $location;
-	}
-
-	public function buildPath($path) {
-		$location = parent::buildPath($path);
 		if ($this->isCaseInsensitiveStorage) {
 			$location = strtolower($location);
 		}

--- a/lib/Storage/ContentListingFormatter.php
+++ b/lib/Storage/ContentListingFormatter.php
@@ -58,6 +58,12 @@ class ContentListingFormatter extends FlysystemContentListingFormatter {
         $this->isCaseInsensitiveStorage = $value;
     }
 
+    /**
+     * This method not part of third party library
+     * If the storage is case insensitive then path should be converted to lowercase
+     * @param  string $path Path to file/folder
+     * @return string       Modified Path
+     */
     public function formatPath($path) {
         if ($this->isCaseInsensitiveStorage) {
             $path = strtolower($path);
@@ -111,7 +117,7 @@ class ContentListingFormatter extends FlysystemContentListingFormatter {
 
     /**
      * Check if the entry resides within the parent directory.
-     *
+     * Update path comparison check using $this->formatPath
      * @param $entry
      *
      * @return bool
@@ -127,7 +133,7 @@ class ContentListingFormatter extends FlysystemContentListingFormatter {
 
     /**
      * Check if the entry is a direct child of the directory.
-     *
+     * Update path comparision check using $this->formatPath
      * @param $entry
      *
      * @return bool

--- a/lib/Storage/ContentListingFormatter.php
+++ b/lib/Storage/ContentListingFormatter.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * @author Hemant Mann <hemant.mann121@gmail.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH.
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+namespace OCA\Files_external_dropbox\Storage;
+
+use League\Flysystem\Util;
+use League\Flysystem\Util\ContentListingFormatter as FlysystemContentListingFormatter;
+
+class ContentListingFormatter extends FlysystemContentListingFormatter {
+    /**
+     * @var string
+     */
+    private $directory;
+    /**
+     * @var bool
+     */
+    private $recursive;
+
+    /**
+     * @var bool
+     */
+    protected $isCaseInsensitiveStorage = false;
+
+    /**
+     * @param string $directory
+     * @param bool   $recursive
+     */
+    public function __construct($directory, $recursive)
+    {
+        $this->directory = $directory;
+        $this->recursive = $recursive;
+    }
+
+    /**
+     * @param bool $value
+     */
+    public function setIsCaseInsensitiveStorage($value) {
+        $this->isCaseInsensitiveStorage = $value;
+    }
+
+    public function formatPath($path) {
+        if ($this->isCaseInsensitiveStorage) {
+            $path = strtolower($path);
+        }
+        return $path;
+    }
+
+    /**
+     * Format contents listing.
+     *
+     * @param array $listing
+     *
+     * @return array
+     */
+    public function formatListing(array $listing)
+    {
+        $listing = array_values(
+            array_map(
+                [$this, 'addPathInfo'],
+                array_filter($listing, [$this, 'isEntryOutOfScope'])
+            )
+        );
+
+        return $this->sortListing($listing);
+    }
+
+    private function addPathInfo(array $entry)
+    {
+        return $entry + Util::pathinfo($entry['path']);
+    }
+
+    /**
+     * Determine if the entry is out of scope.
+     *
+     * @param array $entry
+     *
+     * @return bool
+     */
+    private function isEntryOutOfScope(array $entry)
+    {
+        if (empty($entry['path']) && $entry['path'] !== '0') {
+            return false;
+        }
+
+        if ($this->recursive) {
+            return $this->residesInDirectory($entry);
+        }
+
+        return $this->isDirectChild($entry);
+    }
+
+    /**
+     * Check if the entry resides within the parent directory.
+     *
+     * @param $entry
+     *
+     * @return bool
+     */
+    private function residesInDirectory(array $entry)
+    {
+        if ($this->directory === '') {
+            return true;
+        }
+
+        return strpos($this->formatPath($entry['path']), $this->formatPath($this->directory) . '/') === 0;
+    }
+
+    /**
+     * Check if the entry is a direct child of the directory.
+     *
+     * @param $entry
+     *
+     * @return bool
+     */
+    private function isDirectChild(array $entry)
+    {
+        return Util::dirname($this->formatPath($entry['path'])) === $this->formatPath($this->directory);
+    }
+
+    /**
+     * @param array $listing
+     *
+     * @return array
+     */
+    private function sortListing(array $listing)
+    {
+        usort(
+            $listing,
+            function ($a, $b) {
+                return strcasecmp($a['path'], $b['path']);
+            }
+        );
+
+        return $listing;
+    }
+}

--- a/lib/Storage/Dropbox.php
+++ b/lib/Storage/Dropbox.php
@@ -53,6 +53,7 @@ class Dropbox extends CacheableFlysystemAdapter {
 
     /**
      * This property is used to check whether the storage is case insensitive or not
+     * Override parent value
      * @var boolean
      */
     protected $isCaseInsensitiveStorage = true;

--- a/lib/Storage/Filesystem.php
+++ b/lib/Storage/Filesystem.php
@@ -2,19 +2,19 @@
 /**
  * @author Hemant Mann <hemant.mann121@gmail.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @copyright Copyright (c) 2018, ownCloud GmbH.
  * @license GPL-2.0
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 2 of the License, or (at your option)
  * any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
  * more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -23,30 +23,24 @@
 
 namespace OCA\Files_external_dropbox\Storage;
 
-use Kunnu\Dropbox\Models\FolderMetadata;
-use HemantMann\Flysystem\Dropbox\Adapter as DropboxAdapter;
+use League\Flysystem\Util;
+use League\Flysystem\Filesystem as VendorFilesystem;
 
-class Adapter extends DropboxAdapter {
-	protected function normalizeResponse($obj) {
-		$result = parent::normalizeResponse($obj);
 
-		if ($result['type'] === 'dir') {
-			$result['timestamp'] = 0;
-		}
-		return $result;
-	}
+class Filesystem extends VendorFilesystem {
+    const IS_CASE_INSENSITIVE_STORAGE = 'isCaseInsensitiveStorage';
 
-	public function getModifiedFolders($items) {
-		$result = [];
-		foreach ($items as $item) {
-			$className = FolderMetadata::class;
-			if ($item instanceof $className) {
-				$dirname = $item->getPathDisplay();
-			} else {
-				$dirname = dirname($item->getPathDisplay());
-			}
-			$result[] = $dirname;
-		}
-		return array_unique($result);
-	}
+    /**
+     * @inheritdoc
+     */
+    public function listContents($directory = '', $recursive = false)
+    {
+        $directory = Util::normalizePath($directory);
+        $contents = $this->getAdapter()->listContents($directory, $recursive);
+
+        $contentListFormatter = new ContentListingFormatter($directory, $recursive);
+        $contentListFormatter->setIsCaseInsensitiveStorage($this->getConfig()->get(static::IS_CASE_INSENSITIVE_STORAGE, false));
+
+        return $contentListFormatter->formatListing($contents);
+    }
 }

--- a/lib/Storage/Filesystem.php
+++ b/lib/Storage/Filesystem.php
@@ -39,6 +39,7 @@ class Filesystem extends VendorFilesystem {
         $contents = $this->getAdapter()->listContents($directory, $recursive);
 
         $contentListFormatter = new ContentListingFormatter($directory, $recursive);
+        // Make the formatter aware of the storage type i.e. whether it is case insensitive or not
         $contentListFormatter->setIsCaseInsensitiveStorage($this->getConfig()->get(static::IS_CASE_INSENSITIVE_STORAGE, false));
 
         return $contentListFormatter->formatListing($contents);


### PR DESCRIPTION
Fix for #27 

I have modified the `League\Util\ContentListingFormatter` class which checks whether the file is a part of the current directory or not.

The checks are done based on the property `OCA\Files_external_dropbox\Storage::isCaseInsensitiveStorage`