### PR TITLE
File Exists Stat Cache

### DIFF
--- a/lib/Storage/CacheableFlysystemAdapter.php
+++ b/lib/Storage/CacheableFlysystemAdapter.php
@@ -177,4 +177,12 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 		$info = $this->getFlysystemMetadata($path);
 		return $info['type'];
 	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function file_exists($path) {
+		$info = $this->getFlysystemMetadata($path);
+		return (bool) $info;
+	}
 }

--- a/lib/Storage/CacheableFlysystemAdapter.php
+++ b/lib/Storage/CacheableFlysystemAdapter.php
@@ -144,7 +144,7 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 			return 0;
 		} else {
 			$info = $this->getFlysystemMetadata($path);
-			return $info['size'];
+			return (int) $info['size'];
 		}
 	}
 
@@ -153,7 +153,10 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 	 */
 	public function filemtime($path) {
 		$info = $this->getFlysystemMetadata($path);
-		return $info['timestamp'];
+		if ($info) {	// if $path exists
+			return $info['timestamp'];
+		}
+		return 0;
 	}
 
 	/**
@@ -161,10 +164,13 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 	 */
 	public function stat($path) {
 		$info = $this->getFlysystemMetadata($path);
-		return [
-			'mtime' => $info['timestamp'],
-			'size' => $info['size']
-		];
+		if ($info) {
+			return [
+				'mtime' => $info['timestamp'],
+				'size' => $info['size']
+			];
+		}
+		return false;
 	}
 
 	/**
@@ -175,7 +181,10 @@ abstract class CacheableFlysystemAdapter extends FlysystemStorageAdapter {
 			return 'dir';
 		}
 		$info = $this->getFlysystemMetadata($path);
-		return $info['type'];
+		if ($info) {
+			return $info['type'];
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fix for #26 

After debugging the file upload while trying to fix https://github.com/owncloud/files_external_dropbox/pull/28#issuecomment-356669989

I found that `file_exists` for the storage was called multiple times which was directly hitting the API each time in the same request / response cycle

So I used the existing cacheable layer for the flysystem to prevent multiple calls to the API