### PR TITLE
Update symfony to 3.4.40

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -609,7 +609,7 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.39",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",


### PR DESCRIPTION
```
Generating autoload files
Loading composer repositories with package information
Updating dependencies (including require-dev)                   
Package operations: 0 installs, 1 update, 0 removals
  - Updating symfony/var-dumper (v3.4.39 => v3.4.40): Loading from cache
```
