### PR TITLE
Clean vendor-bin from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ $(composer_dev_deps): $(COMPOSER_BIN) composer.json composer.lock
 .PHONY: clean-composer-deps
 clean-composer-deps:
 	rm -Rf $(composer_deps)
+	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 .PHONY: update-composer
 update-composer: $(COMPOSER_BIN)


### PR DESCRIPTION
So developers can `make clean` properly.