### PR TITLE
Use refresh token

### DIFF
--- a/lib/Controller/OauthController.php
+++ b/lib/Controller/OauthController.php
@@ -28,6 +28,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCA\Files_external_dropbox\OAuth2Store;
 
 /**
  * Oauth controller for Dropbox
@@ -93,10 +94,14 @@ class OauthController extends Controller {
 					$accessTokenData = $accessToken->getData();
 					// consider expiration 10 minutes before the expected time so we can refresh
 					// the token without causing problems
-					$accessTokenData['expTimestamp'] = \time() + $accessTokenData['expires_in'] - 600;
+					$accessTokenData['expTimestamp'] = \time() + $accessTokenData['expires_in'] - OAuth2Store::TOKEN_EXP_OFFSET;
+
+					$oauth2Store = OAuth2Store::getGlobalInstance();
+					$pubToken = $oauth2Store->storeData($accessTokenData, $clientId);
+
 					return new DataResponse([
 						'status' => 'success',
-						'data' => ['token' => \json_encode($accessTokenData)]
+						'data' => ['token' => $pubToken]
 					]);
 				} catch (\Exception $ex) {
 					return new DataResponse([

--- a/lib/OAuth2Store.php
+++ b/lib/OAuth2Store.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez Ramos <jvillafanez@owncloud.com>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_external_dropbox;
+
+use OCP\Security\ICredentialsManager;
+
+/**
+ * Store and retrieve phpseclib3 RSA private keys
+ */
+class OAuth2Store {
+	/**
+	 * Recommended expiration offset the token should have.
+	 * The token should be considered expired in t1 + token_duration - offset
+	 */
+	public const TOKEN_EXP_OFFSET = 600;
+
+	/** @var OAuth2Store */
+	private static $oAuth2Store = null;
+
+	/** @var ICredentialsManager */
+	private $credentialsManager;
+
+	/**
+	 * Get the global instance of the OAuth2Store. If no one is set yet, a new
+	 * one will be created using real server components.
+	 * @return OAuth2Store
+	 */
+	public static function getGlobalInstance(): OAuth2Store {
+		if (self::$oAuth2Store === null) {
+			self::$oAuth2Store = new OAuth2Store(
+				\OC::$server->getCredentialsManager()
+			);
+		}
+		return self::$oAuth2Store;
+	}
+
+	/**
+	 * Set a new OAuth2Store instance as a global instance overwriting whatever
+	 * instance was there.
+	 * This shouldn't be needed outside of unit tests
+	 * @param OAuth2Store|null The OAuth2Store to be set as global instance, or null
+	 * to destroy the global instance (destroying the global instance will allow
+	 * getting the default one again)
+	 */
+	public static function setGlobalInstance(?OAuth2Store $oAuth2Store) {
+		self::$oAuth2Store = $oAuth2Store;
+	}
+
+	/**
+	 * @param ICredentialsManager $credentialsManager
+	 */
+	public function __construct(ICredentialsManager $credentialsManager) {
+		$this->credentialsManager = $credentialsManager;
+	}
+
+	/**
+	 * Store the $accessTokenData. The $clientId will be used as prefix for easier
+	 * identification inside the credentials manager. A token will be returned
+	 * in order to retrieve the stored key
+	 * @param array $accessTokenData the data to be stored
+	 * @param string $clientId a prefix for easier identification
+	 * @return string an opaque token to be used to retrieve the stored key later
+	 */
+	public function storeData(array $accessTokenData, string $clientId): string {
+		$keyId = \uniqid("dropbox:oauth2:$clientId:", true);
+		$this->credentialsManager->store('', $keyId, $accessTokenData);
+
+		$keyData = [
+			'keyId' => $keyId
+		];
+
+		return \base64_encode(\json_encode($keyData));
+	}
+
+	/**
+	 * Retrieve a previously stored access token data using the token that was returned
+	 * when the data was stored
+	 * @param string $token the token returned previously by the "storeData"
+	 * method when the key was stored.
+	 * @return array the access token data that was stored
+	 */
+	public function retrieveData(string $token): ?array {
+		$keyData = \json_decode(\base64_decode($token), true);
+		if ($keyData === null) {
+			return null;
+		}
+		$tokenData = $this->credentialsManager->retrieve('', $keyData['keyId']);
+		return $tokenData;
+	}
+
+	/**
+	 * Update a previously stored access token data using the token that was returned
+	 * when the data was stored
+	 * @param string $token the token returned previously by the "storeData"
+	 * method when the key was stored.
+	 */
+	public function updateData(string $token, array $accessTokenData) {
+		$keyData = \json_decode(\base64_decode($token), true);
+		if ($keyData === null) {
+			return;
+		}
+		$this->credentialsManager->store('', $keyData['keyId'], $accessTokenData);
+	}
+}

--- a/lib/Storage/Adapter.php
+++ b/lib/Storage/Adapter.php
@@ -49,4 +49,11 @@ class Adapter extends DropboxAdapter {
 		}
 		return \array_unique($result);
 	}
+
+	public function refreshToken($oldTokenObj) {
+		$authHelper = $this->client->getAuthHelper();
+		$newTokenObj = $authHelper->getRefreshedAccessToken($oldTokenObj);
+		$this->client->setAccessToken($newTokenObj->getToken());
+		return $newTokenObj;
+	}
 }


### PR DESCRIPTION
Ref https://github.com/owncloud/enterprise/issues/5135

New mounts will use short-lived tokens and use refresh tokens when the access token expires (or is about to expire).
We're assuming the token have a lifetime of 14400 secs (4 hours), but we'll consider the token as expired 10 minutes before the expiration time in order to get a new access token early. If the token is already expired, it shouldn't matter because we'll try to refresh it.

Token information will be stored encrypted in the credentials manager and an opaque token will be used instead in order to access to that information. The implementation is similar to the one used for the RSA keys for the SFTP storage.

Note that since we get the lifetime duration of the token, but not the exact expiration time, we'll have to store the approximate expiration time of the token. As said, we'll include an 10 minute offset.

In case that the expiration time is lost somehow, we'll consider the token as expired and should be refreshed.

For old mounts which still use long-lived tokens, they should still work normally. There is backward-compatibility in place to use those tokens. Note that we can't refresh these tokens, and we don't know when they expire.

In both old and new mounts, if the mount breaks, we'll have to delete and recreate the mount point in order to trigger the oauth authentication flow from start and get a fresh token from the client id and secret.

The expectations for the upgrade are:
* If the mount point is working, there is nothing to be done. The mount point should still be accessible after the upgrade
* If the mount broke at any time (before or after the upgrade), the admin (or user, for personal mounts) will have to delete and recreate the mount