### PR TITLE
[test-onl][full-ci]Replace maihog with inbucket

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,6 @@
 BANST_AWS_CLI = "banst/awscli"
 DRONE_CLI = "drone/cli:alpine"
-MAILHOG_MAILHOG = "mailhog/mailhog"
+INBUCKET_INBUCKET = "inbucket/inbucket"
 MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
@@ -1089,7 +1089,7 @@ def acceptance(ctx):
                         makeParameter = "test-acceptance-cli"
 
                 if testConfig["emailNeeded"]:
-                    environment["MAILHOG_HOST"] = "email"
+                    environment["EMAIL_HOST"] = "email"
 
                 if testConfig["ldapNeeded"]:
                     environment["TEST_WITH_LDAP"] = True
@@ -1408,7 +1408,7 @@ def emailService(emailNeeded):
     if emailNeeded:
         return [{
             "name": "email",
-            "image": MAILHOG_MAILHOG,
+            "image": INBUCKET_INBUCKET,
         }]
 
     return []
@@ -1419,7 +1419,7 @@ def waitForEmailService(emailNeeded):
             "name": "wait-for-email",
             "image": OC_CI_WAIT_FOR,
             "commands": [
-                "wait-for -it email:8025 -t 600",
+                "wait-for -it email:9000 -t 600",
             ],
         }]
 


### PR DESCRIPTION
https://github.com/owncloud/core/pull/40442 changed the email server used in tests from mailhog to inbucket. It also changed the tag used in feature files from `@mailhog` to `@email`

There are no uses of the `@mailhog` tag in this repo. But this PR updates .drone.star to have the same email server code changes as in the other affected apps. For example, see https://github.com/owncloud/guests/pull/531

Issue https://github.com/owncloud/QA/issues/771