### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - XXXX-XX-XX
 
 
+## [2.1.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
 
 ## [2.0.2] - 2024-07-10
 
@@ -75,7 +79,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 Initial release of the application
 
-[Unreleased]: https://github.com/owncloud/files_external_dropbox/compare/v2.0.2...master
+[Unreleased]: https://github.com/owncloud/files_external_dropbox/compare/v2.1.1..master
+[2.1.1]: https://github.com/owncloud/files_external_dropbox/compare/v2.1.0..v2.1.1
 [2.0.2]: https://github.com/owncloud/files_external_dropbox/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/owncloud/files_external_dropbox/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/owncloud/files_external_dropbox/compare/v1.2.0...v2.0.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ Administrators and users (when enabled) can find external storage configuration 
     <summary>Integrate Dropbox as an external storage</summary>
     <licence>GPLv2</licence>
     <author>Hemant Mann</author>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <category>storage</category>
     <documentation>
     	<user>https://doc.owncloud.com/server/latest/user_manual/external_storage/external_storage.html?highlight=dropbox</user>


### PR DESCRIPTION
Patch-level version bump (2.1.0 -> 2.1.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.